### PR TITLE
Improve verifyPhoneNumber for Android.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,13 @@ typings/
 # dotenv environment variables file
 .env
 
+
+\.idea/cordova-plugin-firebase-authentication\.iml
+
+\.idea/misc\.xml
+
+\.idea/modules\.xml
+
+\.idea/vcs\.xml
+
+\.idea/workspace\.xml

--- a/README.md
+++ b/README.md
@@ -83,10 +83,16 @@ cordova.plugins.firebase.auth.verifyPhoneNumber("+123456789", 30000, (success) {
         if (success.type === 'onCodeSent') {
             // succeess.verificationId = verificationId
             // succeess.SMS = 'undefined'
+            // Save the verification id here.
         } else if (success.type === 'onVerificationCompleted') {
             // succeess.verificationId = undefined
             if (succeess.SMS !== null) {
                 // succeess.SMS = '732748' Login using SMS code.
+                // If you want to log in using the web version of firebase:
+                let signInCredential = firebase.auth.PhoneAuthProvider.credential(savedVerificationId, succeess.SMS)
+                auth.signInAndRetrieveDataWithCredential(signInCredential).then((user) => {})
+                // OR if you want to log in natively:
+                cordova.plugins.firebase.auth.signInWithVerificationId(savedVerificationId, succeess.SMS)
             } else {
                 // Instant verification took place. To login please call signInWithPhoneAutoVerification
                 cordova.plugins.firebase.auth.signInWithPhoneAutoVerification() // This is the only acceptable place to call this function.
@@ -102,6 +108,7 @@ cordova.plugins.firebase.auth.verifyPhoneNumber("+123456789", 30000, (success) {
     }
 });
 ```
+
 
 ### signInWithPhoneAutoVerification()
 Signs user in after instant verification. Refer to the example in `verifyPhoneNumber` for usage instructions. 

--- a/plugin.xml
+++ b/plugin.xml
@@ -35,7 +35,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     </platform>
 
     <platform name="android">
-        <preference name="FIREBASE_AUTH_VERSION" default="16.0.+"/>
+        <preference name="FIREBASE_AUTH_VERSION" default="16.1.+"/>
 
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="FirebaseAuthentication">

--- a/src/android/FirebaseAuthenticationPlugin.java
+++ b/src/android/FirebaseAuthenticationPlugin.java
@@ -18,10 +18,6 @@ import com.google.firebase.auth.PhoneAuthCredential;
 import com.google.firebase.auth.PhoneAuthProvider;
 import com.google.firebase.auth.TwitterAuthProvider;
 import com.google.firebase.FirebaseException;
-import com.google.firebase.auth.FirebaseAuthException;
-import com.google.firebase.FirebaseTooManyRequestsException;
-import com.google.firebase.FirebaseApiNotAvailableException;
-import com.google.firebase.auth.FirebaseAuthInvalidCredentialsException;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.PluginResult;
@@ -30,8 +26,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import java.util.HashMap;
-import java.util.Map;
 
 
 public class FirebaseAuthenticationPlugin extends ReflectiveCordovaPlugin implements AuthStateListener {
@@ -50,8 +44,6 @@ public class FirebaseAuthenticationPlugin extends ReflectiveCordovaPlugin implem
 
         this.firebaseAuth = FirebaseAuth.getInstance();
         this.phoneAuthProvider = PhoneAuthProvider.getInstance();
-        this.mForceResendingTokenStore = null;
-        this.mCredential = null;
     }
 
     @CordovaMethod
@@ -238,28 +230,6 @@ public class FirebaseAuthenticationPlugin extends ReflectiveCordovaPlugin implem
         }
 
         return exceptionMap;
-    }
-
-    private void signInWithPhoneCredential(PhoneAuthCredential credential) {
-        FirebaseUser user = firebaseAuth.getCurrentUser();
-
-        if (user == null) {
-            firebaseAuth.signInWithCredential(credential)
-                .addOnCompleteListener(cordova.getActivity(), FirebaseAuthenticationPlugin.this);
-        } else {
-            user.updatePhoneNumber(credential)
-                .addOnCompleteListener(cordova.getActivity(), FirebaseAuthenticationPlugin.this);
-        }
-    }
-
-    @CordovaMethod
-    private void signInWithPhoneAutoVerification(final CallbackContext callbackContext) {
-        if (mCredential != null) {
-            signInWithPhoneCredential(mCredential);
-            callbackContext.success();
-        } else {
-            callbackContext.error("No credential present.");
-        }
     }
 
     @CordovaMethod

--- a/src/android/FirebaseAuthenticationPlugin.java
+++ b/src/android/FirebaseAuthenticationPlugin.java
@@ -18,6 +18,10 @@ import com.google.firebase.auth.PhoneAuthCredential;
 import com.google.firebase.auth.PhoneAuthProvider;
 import com.google.firebase.auth.TwitterAuthProvider;
 import com.google.firebase.FirebaseException;
+import com.google.firebase.auth.FirebaseAuthException;
+import com.google.firebase.FirebaseTooManyRequestsException;
+import com.google.firebase.FirebaseApiNotAvailableException;
+import com.google.firebase.auth.FirebaseAuthInvalidCredentialsException;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.PluginResult;
@@ -26,6 +30,8 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import java.util.HashMap;
+import java.util.Map;
 
 
 public class FirebaseAuthenticationPlugin extends ReflectiveCordovaPlugin implements AuthStateListener {

--- a/www/FirebaseAuthentication.js
+++ b/www/FirebaseAuthentication.js
@@ -49,14 +49,19 @@ module.exports = {
             exec(resolve, reject, PLUGIN_NAME, "signInWithTwitter", [token, secret]);
         });
     },
-    verifyPhoneNumber: function(phoneNumber, timeoutMillis) {
-        return new Promise(function(resolve, reject) {
-            exec(resolve, reject, PLUGIN_NAME, "verifyPhoneNumber", [phoneNumber, timeoutMillis]);
-        });
+    verifyPhoneNumber: function(phoneNumber, timeoutMillis, success, failure) {
+        // return new Promise(function(resolve, reject) {
+        exec(success, failure, PLUGIN_NAME, "verifyPhoneNumber", [phoneNumber, timeoutMillis]);
+        // });
     },
     signInWithVerificationId: function(verificationId, code) {
         return new Promise(function(resolve, reject) {
             exec(resolve, reject, PLUGIN_NAME, "signInWithVerificationId", [verificationId, code]);
+        });
+    },
+    signInWithPhoneAutoVerification: function() {
+        return new Promise(function(resolve, reject) {
+            exec(resolve, reject, PLUGIN_NAME, "signInWithPhoneAutoVerification", []);
         });
     },
     signOut: function() {


### PR DESCRIPTION
- Allowed more verbose callbacks, allowing more control by the end user for the different authentication flows.
- Removes promises from callback, as they were preventing the native callbacks from propagating (You can only receive one callback with a promise)
- Allowed force resending pin.
- Improved error callbacks.
- Updated readme accordingly.

This update improves the login flow, as it allows the user to log in natively or with the web version of firebase auth.
Provides solutions to:
#46 #43 #40 #23 