### PR TITLE
Implemented setAuthStateChanged for iOS and added getCurrentUser (iOS and Android)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,9 @@ Every method call returns a promise which is optionally fulfilled with an approp
 ### getCurrentUser()
 Returns the current user in the Firebase instance.
 ```js
-cordova.plugins.firebase.auth.getCurrentUser()
-	.then(function(userInfo) {
-		// user information
-	})
-	.catch(function(err) {
-		// user is not logged in
-	});
+cordova.plugins.firebase.auth.getCurrentUser().then(function(userInfo) {
+    // user information or null if not logged in
+})
 ```
 
 ### getIdToken(_forceRefresh_)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@ To use phone number authentication on iOS, your app must be able to receive sile
 ## Methods
 Every method call returns a promise which is optionally fulfilled with an appropriate value.
 
+### getCurrentUser()
+Returns the current user in the Firebase instance.
+```js
+cordova.plugins.firebase.auth.getCurrentUser()
+	.then(function(userInfo) {
+		// user information
+	})
+	.catch(function(err) {
+		// user is not logged in
+	});
+```
+
 ### getIdToken(_forceRefresh_)
 Returns a JWT token used to identify the user to a Firebase service.
 ```js

--- a/src/android/FirebaseAuthenticationPlugin.java
+++ b/src/android/FirebaseAuthenticationPlugin.java
@@ -45,6 +45,16 @@ public class FirebaseAuthenticationPlugin extends ReflectiveCordovaPlugin implem
     }
 
     @CordovaMethod
+    private void getCurrentUser(final CallbackContext callbackContext) {
+        FirebaseUser user = firebaseAuth.getCurrentUser();
+        if (user == null) {
+            callbackContext.error("User is not authorized");
+        } else {
+            callbackContext.success(getProfileData(user));
+        }
+    }
+
+    @CordovaMethod
     private void getIdToken(boolean forceRefresh, final CallbackContext callbackContext) {
         FirebaseUser user = firebaseAuth.getCurrentUser();
 

--- a/src/android/FirebaseAuthenticationPlugin.java
+++ b/src/android/FirebaseAuthenticationPlugin.java
@@ -48,7 +48,7 @@ public class FirebaseAuthenticationPlugin extends ReflectiveCordovaPlugin implem
     private void getCurrentUser(final CallbackContext callbackContext) {
         FirebaseUser user = firebaseAuth.getCurrentUser();
         if (user == null) {
-            callbackContext.error("User is not authorized");
+            callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, (String)null));
         } else {
             callbackContext.success(getProfileData(user));
         }

--- a/src/ios/FirebaseAuthenticationPlugin.h
+++ b/src/ios/FirebaseAuthenticationPlugin.h
@@ -2,6 +2,7 @@
 
 @interface FirebaseAuthenticationPlugin : CDVPlugin
 
+- (void)getCurrentUser:(CDVInvokedUrlCommand*)command;
 - (void)getIdToken:(CDVInvokedUrlCommand*)command;
 - (void)createUserWithEmailAndPassword:(CDVInvokedUrlCommand*)command;
 - (void)sendEmailVerification:(CDVInvokedUrlCommand*)command;
@@ -15,5 +16,6 @@
 - (void)verifyPhoneNumber:(CDVInvokedUrlCommand*)command;
 - (void)signOut:(CDVInvokedUrlCommand*)command;
 - (void)setLanguageCode:(CDVInvokedUrlCommand*)command;
+- (void)setAuthStateChanged:(CDVInvokedUrlCommand*)command;
 
 @end

--- a/src/ios/FirebaseAuthenticationPlugin.m
+++ b/src/ios/FirebaseAuthenticationPlugin.m
@@ -1,6 +1,12 @@
 #import "FirebaseAuthenticationPlugin.h"
 @import Firebase;
 
+@interface FirebaseAuthenticationPlugin() {
+    NSString* authChangedCallbackId;
+}
+@property(strong, nonatomic) FIRAuthStateDidChangeListenerHandle handle;
+@end
+
 @implementation FirebaseAuthenticationPlugin
 
 - (void)pluginInitialize {
@@ -8,6 +14,17 @@
 
     if(![FIRApp defaultApp]) {
         [FIRApp configure];
+    }
+}
+
+- (void)getCurrentUser:(CDVInvokedUrlCommand *)command {
+    FIRUser *user = [FIRAuth auth].currentUser;
+    if (user) {
+        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:[self userToDictionary:user]];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+    } else {
+        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"User must be signed in"];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     }
 }
 
@@ -196,6 +213,28 @@
 
     CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
+- (void)setAuthStateChanged:(CDVInvokedUrlCommand*)command {
+    BOOL disable = [[command.arguments objectAtIndex:0] boolValue];
+    if (_handle) {
+        // [START remove_auth_listener]
+        [[FIRAuth auth] removeAuthStateDidChangeListener:_handle];
+        self.handle = nil;
+        // [END remove_auth_listener]
+    }
+    if (!disable) {
+        authChangedCallbackId = [command.callbackId copy];
+        // [START auth_listener]
+        self.handle = [[FIRAuth auth]
+            addAuthStateDidChangeListener:^(FIRAuth *_Nonnull auth, FIRUser *_Nullable user) {
+                // [START_EXCLUDE]
+                CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:[self userToDictionary:user]];
+                [self.commandDelegate sendPluginResult:pluginResult callbackId:authChangedCallbackId];
+                // [END_EXCLUDE]
+            }];
+        // [END auth_listener]
+    }
 }
 
 - (CDVPluginResult*) createAuthResult:(FIRAuthDataResult*)result withError:(NSError*)error {

--- a/src/ios/FirebaseAuthenticationPlugin.m
+++ b/src/ios/FirebaseAuthenticationPlugin.m
@@ -248,6 +248,9 @@
 }
 
 - (NSDictionary*)userToDictionary:(FIRUser *)user {
+    if (!user) {
+        return @{};
+    }
     return @{
         @"uid": user.uid,
         @"providerId": user.providerID,

--- a/src/ios/FirebaseAuthenticationPlugin.m
+++ b/src/ios/FirebaseAuthenticationPlugin.m
@@ -19,13 +19,8 @@
 
 - (void)getCurrentUser:(CDVInvokedUrlCommand *)command {
     FIRUser *user = [FIRAuth auth].currentUser;
-    if (user) {
-        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:[self userToDictionary:user]];
-        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
-    } else {
-        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"User must be signed in"];
-        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
-    }
+    CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:[self userToDictionary:user]];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 - (void)getIdToken:(CDVInvokedUrlCommand *)command {
@@ -218,23 +213,17 @@
 - (void)setAuthStateChanged:(CDVInvokedUrlCommand*)command {
     BOOL disable = [[command.arguments objectAtIndex:0] boolValue];
     if (_handle) {
-        // [START remove_auth_listener]
         [[FIRAuth auth] removeAuthStateDidChangeListener:_handle];
         self.handle = nil;
-        // [END remove_auth_listener]
     }
     if (!disable) {
         authChangedCallbackId = [command.callbackId copy];
-        // [START auth_listener]
         self.handle = [[FIRAuth auth]
             addAuthStateDidChangeListener:^(FIRAuth *_Nonnull auth, FIRUser *_Nullable user) {
-                // [START_EXCLUDE]
                 CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:[self userToDictionary:user]];
                 [pluginResult setKeepCallbackAsBool:YES];
                 [self.commandDelegate sendPluginResult:pluginResult callbackId:authChangedCallbackId];
-                // [END_EXCLUDE]
             }];
-        // [END auth_listener]
     }
 }
 
@@ -250,7 +239,7 @@
 
 - (NSDictionary*)userToDictionary:(FIRUser *)user {
     if (!user) {
-        return @{};
+        return nil;
     }
     return @{
         @"uid": user.uid,

--- a/src/ios/FirebaseAuthenticationPlugin.m
+++ b/src/ios/FirebaseAuthenticationPlugin.m
@@ -230,6 +230,7 @@
             addAuthStateDidChangeListener:^(FIRAuth *_Nonnull auth, FIRUser *_Nullable user) {
                 // [START_EXCLUDE]
                 CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:[self userToDictionary:user]];
+                [pluginResult setKeepCallbackAsBool:YES];
                 [self.commandDelegate sendPluginResult:pluginResult callbackId:authChangedCallbackId];
                 // [END_EXCLUDE]
             }];

--- a/www/FirebaseAuthentication.js
+++ b/www/FirebaseAuthentication.js
@@ -2,6 +2,11 @@ var exec = require("cordova/exec");
 var PLUGIN_NAME = "FirebaseAuthentication";
 
 module.exports = {
+    getCurrentUser: function () {
+        return new Promise(function (resolve, reject) {
+            exec(resolve, reject, PLUGIN_NAME, "getCurrentUser", []);
+        });
+    },
     getIdToken: function(forceRefresh) {
         return new Promise(function(resolve, reject) {
             if (forceRefresh == null) forceRefresh = false;


### PR DESCRIPTION
This implements the missing method setAuthStateChanged in the iOS version of the plugin.
It also adds the method getCurrentUser() to request the current user in the Firebase Auth instance.