### PR TITLE
Added completeListener onVerificationCompleted hook

### DIFF
--- a/src/android/FirebaseAuthenticationPlugin.java
+++ b/src/android/FirebaseAuthenticationPlugin.java
@@ -161,7 +161,7 @@ public class FirebaseAuthenticationPlugin extends ReflectiveCordovaPlugin implem
                 new PhoneAuthProvider.OnVerificationStateChangedCallbacks() {
                     @Override
                     public void onVerificationCompleted(PhoneAuthCredential credential) {
-                        signInWithPhoneCredential(credential);
+                        signInWithPhoneCredential(credential).addOnCompleteListener(cordova.getActivity(), createCompleteListener(callbackContext));
                     }
 
                     @Override


### PR DESCRIPTION
When instant verification occurs on android, signInWithPhoneCredential() is executed without resolving promise for verifyPhoneNumber.
Ofcourse we can listen for authStateChanged but getting success/error message on the promise can be handy sometimes.

This pull request adds complete listener that will return success/error status to the promise.