### PR TITLE
add getPhoneNumberVerificationId function

### DIFF
--- a/www/FirebaseAuthentication.js
+++ b/www/FirebaseAuthentication.js
@@ -68,6 +68,17 @@ module.exports = {
     },
     verifyPhoneNumber: function(phoneNumber, timeoutMillis) {
         return new Promise(function(resolve, reject) {
+            exec(function(verificationId) {
+                resolve(function(code) {
+                    return new Promise(function(resolve, reject) {
+                        exec(resolve, reject, PLUGIN_NAME, "signInWithVerificationId", [verificationId, code]);
+                    });
+                });
+            }, reject, PLUGIN_NAME, "verifyPhoneNumber", [phoneNumber, timeoutMillis]);
+        });
+    },
+    getPhoneNumberVerificationId: function(phoneNumber, timeoutMillis) {
+        return new Promise(function(resolve, reject) {
             exec(resolve, reject, PLUGIN_NAME, "verifyPhoneNumber", [phoneNumber, timeoutMillis]);
         });
     },

--- a/www/FirebaseAuthentication.js
+++ b/www/FirebaseAuthentication.js
@@ -68,13 +68,7 @@ module.exports = {
     },
     verifyPhoneNumber: function(phoneNumber, timeoutMillis) {
         return new Promise(function(resolve, reject) {
-            exec(function(verificationId) {
-                resolve(function(code) {
-                    return new Promise(function(resolve, reject) {
-                        exec(resolve, reject, PLUGIN_NAME, "signInWithVerificationId", [verificationId, code]);
-                    });
-                });
-            }, reject, PLUGIN_NAME, "verifyPhoneNumber", [phoneNumber, timeoutMillis]);
+            exec(resolve, reject, PLUGIN_NAME, "verifyPhoneNumber", [phoneNumber, timeoutMillis]);
         });
     },
     signInWithCustomToken: function (idToken) {


### PR DESCRIPTION
It should be possible to get the `verificationId` from `verifyPhoneNumber` in order to handle the login process with the official JS firebase library:
```
verificationId = await this.firebaseAuthentication.getPhoneNumberVerificationId(phoneNumber, 30000);
/* ask smsCode to user */
authCredential = firebase.auth.PhoneAuthProvider.credential(verificationId, smsCode);
userCredential = await firebase.auth().signInWithCredential(authCredential);
```